### PR TITLE
fixed mixed little and big endian values in raw data

### DIFF
--- a/software/raspberrypi_qt/mainwindow.cpp
+++ b/software/raspberrypi_qt/mainwindow.cpp
@@ -71,6 +71,7 @@ void MainWindow::saveSnapshot() {
     QFile rawFile(QString("raw%1.bin").arg(snapshotCount));
     rawFile.open(QIODevice::Truncate | QIODevice::ReadWrite);
     QDataStream rawOut(&rawFile);
+    rawOut.setByteOrder(QDataStream::LittleEndian);
     rawOut << rawMin << rawMax;
     rawOut.writeRawData((char *) &rawData[0], 2*rawData.size());
     rawFile.close();


### PR DESCRIPTION
In the original code, minimum and maximum value data have been saved as big endian, and remains saved as little endian in raw data file.
