### PR TITLE
Runtime arguments support

### DIFF
--- a/software/flirpi/fblept.c
+++ b/software/flirpi/fblept.c
@@ -105,21 +105,25 @@ static void writefb(void)
 
 #include "leptsci.h"
 
+char *spidev = "/dev/spidev0.0";
+
 void usage(char *exec)
 {
     printf("Usage: %s [options]\n"
            "Options:\n"
            "  -c | --contour           Set contour to 1\n"
+           "  -d | --device name       spidev device name (%s by default)\n"
            "  -h | --help              Print this message\n"
            "  -m | --magnify factor    Force given factor as magnify factor "
                "instead of auto-calculated one\n"
-           "", exec);
+           "", exec, spidev);
 }
 
-static const char short_options [] = "chm:";
+static const char short_options [] = "cd:hm:";
 
 static const struct option long_options [] = {
     { "contour", no_argument,       NULL, 'c' },
+    { "device",  required_argument, NULL, 'd' },
     { "help",    no_argument,       NULL, 'h' },
     { "magnify", required_argument, NULL, 'm' },
     { 0, 0, 0, 0 }
@@ -148,6 +152,10 @@ int main(int argc, char *argv[])
 
             case 'c':
                 contour = 1;
+                break;
+
+            case 'd':
+                spidev = optarg;
                 break;
 
             case 'h':
@@ -187,7 +195,7 @@ int main(int argc, char *argv[])
     xo = (vinfo.xres - WD * mag) / 2 + vinfo.xoffset;
     yo = (vinfo.yres - HT * mag) / 2 + vinfo.yoffset;
 printf( "%d,%d,%d,%d\n",xo,yo,80*mag,60*mag );
-    if (leptopen())
+    if (leptopen(spidev))
         return -7;
 
     for (;;) {

--- a/software/flirpi/leptbmp.c
+++ b/software/flirpi/leptbmp.c
@@ -76,7 +76,7 @@ static void writebmp(void)
 
 int main(int argc, char *argv[])
 {
-    if (leptopen() || leptget((unsigned short *) img))
+    if (leptopen(NULL) || leptget((unsigned short *) img))
         return -1;
     leptclose();
     writebmp();

--- a/software/flirpi/leptgraypng.c
+++ b/software/flirpi/leptgraypng.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
 
     for (y = 0; y < HT; y++)
         rps[y] = image + WD * 2 * y;
-    if (leptopen() || leptget(simage))
+    if (leptopen(NULL) || leptget(simage))
         return -1;
     leptclose();
 

--- a/software/flirpi/leptsci.c
+++ b/software/flirpi/leptsci.c
@@ -11,13 +11,19 @@ static uint32_t speed = 16000000;       //16
 static uint16_t delay = 0;
 static int leptfd;
 
-int leptopen()
+int leptopen(char *device)
 {
     uint8_t mode = 0;
-    const char device[] = "/dev/spidev0.0";
-    leptfd = open(device, O_RDWR);
-    if (leptfd < 0)
+    char *spidev = "/dev/spidev0.0";
+
+    if (device)
+        spidev = device;
+
+    leptfd = open(spidev, O_RDWR);
+    if (leptfd < 0) {
+        perror("spidev device");
         return -1;
+    }
     if (-1 == ioctl(leptfd, SPI_IOC_WR_MODE, &mode))
         return -2;
     if (-1 == ioctl(leptfd, SPI_IOC_RD_MODE, &mode))

--- a/software/flirpi/leptsci.h
+++ b/software/flirpi/leptsci.h
@@ -1,3 +1,3 @@
-int leptopen(void);
+int leptopen(char *dev);
 int leptget(unsigned short *);
 int leptclose(void);

--- a/software/v4l2lepton/README.md
+++ b/software/v4l2lepton/README.md
@@ -1,6 +1,6 @@
 Released under GPLv3
 
-This is a simple program designed for Raspberry Pi that reads frames from the FLIR Lepton and streams them to a v4l2loopback device. This program would be very useful if you want to stream the Lepton like any other webcam. Maybe you want to process the Lepton frames using a library that can read standard v4l2 devices, like OpenCV. Anything you can do with a webcam, this program will allow you to do it with the Lepton + basic breakout board.
+This is a simple program initially designed for Raspberry Pi that reads frames from the FLIR Lepton and streams them to a v4l2loopback device. This program would be very useful if you want to stream the Lepton like any other webcam. Maybe you want to process the Lepton frames using a library that can read standard v4l2 devices, like OpenCV. Anything you can do with a webcam, this program will allow you to do it with the Lepton + basic breakout board.
 
 Code is borrowed from raspberrypi_video as well as the ondemandcam example provided with v4l2loopback.
 
@@ -23,6 +23,7 @@ To Compile v4l2lepton:
 
 To Run v4l2lepton:
 
-    ./v4l2lepton /dev/videoX
+    ./v4l2lepton -v /dev/videoX -d /dev/spidevY.Z
 
+If spidev device is not given /dev/spidev0.1 will be used by default.  
 You can confirm that the stream is working by using something like VLC Media Player and opening /dev/videoX as a capture device. Anything that can interface with v4l2 devices can use it though.

--- a/software/v4l2lepton/SPI.cpp
+++ b/software/v4l2lepton/SPI.cpp
@@ -1,17 +1,14 @@
 #include "SPI.h"
 
-int spi_cs0_fd = -1;
-int spi_cs1_fd = -1;
+int spi_cs_fd = -1;
 
 unsigned char spi_mode = SPI_MODE_3;
 unsigned char spi_bitsPerWord = 8;
 unsigned int spi_speed = 10000000;
 
-int SpiOpenPort (int spi_device)
+int SpiOpenPort (char* spi_device)
 {
 	int status_value = -1;
-	int *spi_cs_fd;
-
 
 	//----- SET SPI MODE -----
 	//SPI_MODE_0 (0,0)  CPOL=0 (Clock Idle low level), CPHA=0 (SDO transmit/change edge active to idle)
@@ -26,60 +23,53 @@ int SpiOpenPort (int spi_device)
 	//----- SET SPI BUS SPEED -----
 	spi_speed = 10000000;				//1000000 = 1MHz (1uS per bit)
 
-
 	if (spi_device)
-		spi_cs_fd = &spi_cs1_fd;
+		spi_cs_fd = open(std::string(spi_device).c_str(), O_RDWR);
 	else
-		spi_cs_fd = &spi_cs0_fd;
+		spi_cs_fd = open(std::string("/dev/spidev0.1").c_str(), O_RDWR);
 
-
-	if (spi_device)
-		*spi_cs_fd = open(std::string("/dev/spidev0.1").c_str(), O_RDWR);
-	else
-		*spi_cs_fd = open(std::string("/dev/spidev0.1").c_str(), O_RDWR);
-
-	if (*spi_cs_fd < 0)
+	if (spi_cs_fd < 0)
 	{
 		perror("Error - Could not open SPI device");
 		exit(1);
 	}
 
-	status_value = ioctl(*spi_cs_fd, SPI_IOC_WR_MODE, &spi_mode);
+	status_value = ioctl(spi_cs_fd, SPI_IOC_WR_MODE, &spi_mode);
 	if(status_value < 0)
 	{
 		perror("Could not set SPIMode (WR)...ioctl fail");
 		exit(1);
 	}
 
-	status_value = ioctl(*spi_cs_fd, SPI_IOC_RD_MODE, &spi_mode);
+	status_value = ioctl(spi_cs_fd, SPI_IOC_RD_MODE, &spi_mode);
 	if(status_value < 0)
 	{
 		perror("Could not set SPIMode (RD)...ioctl fail");
 		exit(1);
 	}
 
-	status_value = ioctl(*spi_cs_fd, SPI_IOC_WR_BITS_PER_WORD, &spi_bitsPerWord);
+	status_value = ioctl(spi_cs_fd, SPI_IOC_WR_BITS_PER_WORD, &spi_bitsPerWord);
 	if(status_value < 0)
 	{
 		perror("Could not set SPI bitsPerWord (WR)...ioctl fail");
 		exit(1);
 	}
 
-	status_value = ioctl(*spi_cs_fd, SPI_IOC_RD_BITS_PER_WORD, &spi_bitsPerWord);
+	status_value = ioctl(spi_cs_fd, SPI_IOC_RD_BITS_PER_WORD, &spi_bitsPerWord);
 	if(status_value < 0)
 	{
 		perror("Could not set SPI bitsPerWord(RD)...ioctl fail");
 		exit(1);
 	}
 
-	status_value = ioctl(*spi_cs_fd, SPI_IOC_WR_MAX_SPEED_HZ, &spi_speed);
+	status_value = ioctl(spi_cs_fd, SPI_IOC_WR_MAX_SPEED_HZ, &spi_speed);
 	if(status_value < 0)
 	{
 		perror("Could not set SPI speed (WR)...ioctl fail");
 		exit(1);
 	}
 
-	status_value = ioctl(*spi_cs_fd, SPI_IOC_RD_MAX_SPEED_HZ, &spi_speed);
+	status_value = ioctl(spi_cs_fd, SPI_IOC_RD_MAX_SPEED_HZ, &spi_speed);
 	if(status_value < 0)
 	{
 		perror("Could not set SPI speed (RD)...ioctl fail");
@@ -88,18 +78,11 @@ int SpiOpenPort (int spi_device)
 	return(status_value);
 }
 
-int SpiClosePort(int spi_device)
+int SpiClosePort(void)
 {
-		int status_value = -1;
-	int *spi_cs_fd;
+	int status_value = -1;
 
-	if (spi_device)
-		spi_cs_fd = &spi_cs1_fd;
-	else
-		spi_cs_fd = &spi_cs0_fd;
-
-
-	status_value = close(*spi_cs_fd);
+	status_value = close(spi_cs_fd);
 	if(status_value < 0)
 	{
 		perror("Error - Could not close SPI device");

--- a/software/v4l2lepton/SPI.h
+++ b/software/v4l2lepton/SPI.h
@@ -25,13 +25,12 @@
 #include <linux/types.h>
 #include <linux/spi/spidev.h>
 
-extern int spi_cs0_fd;
-extern int spi_cs1_fd;
+extern int spi_cs_fd;
 extern unsigned char spi_mode;
 extern unsigned char spi_bitsPerWord;
 extern unsigned int spi_speed;
 
-int SpiOpenPort(int spi_device);
-int SpiClosePort(int spi_device);
+int SpiOpenPort(char *device);
+int SpiClosePort(void);
 
 #endif

--- a/software/v4l2lepton/v4l2lepton.cpp
+++ b/software/v4l2lepton/v4l2lepton.cpp
@@ -158,12 +158,56 @@ static void *sendvid(void *v)
     }
 }
 
+void usage(char *exec)
+{
+    printf("Usage: %s [options]\n"
+           "Options:\n"
+           "  -h | --help              Print this message\n"
+           "  -v | --video name        Use name as v4l2loopback device (%s by default)\n"
+           "", exec, v4l2dev);
+}
+
+static const char short_options [] = "hv:";
+
+static const struct option long_options [] = {
+    { "help",    no_argument,       NULL, 'h' },
+    { "video",   required_argument, NULL, 'v' },
+    { 0, 0, 0, 0 }
+};
+
 int main(int argc, char **argv)
 {
     struct timespec ts;
 
-    if( argc == 2 )
-        v4l2dev = argv[1];
+    // processing command line parameters
+    for (;;) {
+        int index;
+        int c;
+
+        c = getopt_long(argc, argv,
+                        short_options, long_options,
+                        &index);
+
+        if (-1 == c)
+            break;
+
+        switch (c) {
+            case 0:
+                break;
+
+            case 'h':
+                usage(argv[0]);
+                exit(EXIT_SUCCESS);
+
+            case 'v':
+                v4l2dev = optarg;
+                break;
+
+            default:
+                usage(argv[0]);
+                exit(EXIT_FAILURE);
+        }
+    }
 
     open_vpipe();
 


### PR DESCRIPTION
Hello,
these 5 commits add runtime arguments support to fblept and v4l2lepton tools. These tools are then able to run on other platforms than RPi without modifying/recompiling them (tested on i.MX6 & i.MX6UL SOMs from Armadeus Systems) .
Kind regards,
Julien